### PR TITLE
Fix outline header jumping in long documents

### DIFF
--- a/src/components/CMEditor.tsx
+++ b/src/components/CMEditor.tsx
@@ -267,7 +267,8 @@ export const CMEditor = React.forwardRef<CMHandle, Props>(function CMEditor(
           // After changes or cursor moves, update active heading from caret when user-driven
           if ((u.docChanged || u.selectionSet) && !isProgrammaticSelect) {
             const caret = u.state.selection.main.head;
-            const index = new OutlineIndex(outlineRef.current.map(h => ({ id: h.id, pos: h.offset })));
+            // Use a stable "at or before" lookup to avoid jumping between headings while typing
+            const index = new OutlineIndex(outlineRef.current);
             const nextId = index.idAtOrBefore(caret);
             if (nextId && nextId !== lastActiveIdRef.current) {
               lastActiveIdRef.current = nextId;

--- a/src/core/outlineCore.ts
+++ b/src/core/outlineCore.ts
@@ -32,6 +32,33 @@ export class OutlineIndex {
     return lo;
   }
 
+  /**
+   * Return the index of the last heading whose offset <= given offset.
+   * If the offset is before the first heading, returns 0 when any heading exists, or -1 otherwise.
+   * This is the stable choice for "current section" based on caret position.
+   */
+  indexAtOrBefore(offset: number): number {
+    const n = this.offsets.length;
+    if (n === 0) return -1;
+    let lo = 0, hi = n - 1, ans = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (this.offsets[mid] <= offset) {
+        ans = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return ans === -1 ? 0 : ans;
+  }
+
+  /** Convenience: id of heading at or before the given offset */
+  idAtOrBefore(offset: number): string | null {
+    const i = this.indexAtOrBefore(offset);
+    return i >= 0 && i < this.items.length ? this.items[i].id : null;
+  }
+
   ancestorChain(idx: number): number[] {
     if (idx < 0 || idx >= this.items.length) return [];
     const chain: number[] = [];


### PR DESCRIPTION
Add stable 'at or before caret' lookup for active outline headings and fix OutlineIndex construction to prevent outline jumps in long documents.

The active heading selection previously suffered from instability and an incorrect `OutlineIndex` data shape, leading to outline items jumping during edits in long documents. This fix introduces a deterministic `idAtOrBefore` method that reliably identifies the current section by selecting the last heading whose offset is at or before the caret, ensuring stable outline synchronization.

---
<a href="https://cursor.com/background-agent?bcId=bc-e913ef1a-dbf3-4047-b87c-7e28800225b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e913ef1a-dbf3-4047-b87c-7e28800225b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

